### PR TITLE
feat(cli): initialize CLI with core functionality

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,5 @@
+cli/
+.drafts/
+*.log
+node_modules/
+.env*

--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -1,0 +1,49 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# env files (can opt-in for committing if needed)
+.env*
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts
+
+# drafts
+.drafts
+.draft
+draft
+/.drafts
+/.draft
+/draft

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,75 @@
+# Motion Primitives CLI
+
+A command-line interface for easily adding beautiful, animated components to your React project.
+
+## Installation
+
+You can use the CLI directly with npx:
+
+```bash
+npx motion-primitives <command>
+```
+
+Or install it globally:
+
+```bash
+npm install -g motion-primitives
+motion-primitives <command>
+```
+
+## Usage
+
+### List available components
+
+To see all available animated components:
+
+```bash
+npx motion-primitives list
+```
+
+This will display a list of all available components along with descriptions and required dependencies.
+
+### Add a component
+
+To add a specific component to your project:
+
+```bash
+npx motion-primitives add <component-name>
+```
+
+For example:
+
+```bash
+npx motion-primitives add text-morph
+```
+
+This will:
+
+1. Create a `components/motion-primitives` directory in your project (if it doesn't exist)
+2. Download and add the component files
+3. Automatically install any required dependencies using your preferred package manager (npm, yarn, or pnpm)
+
+The CLI automatically detects which package manager you're using based on lock files in your project.
+
+## Available Components
+
+Motion Primitives offers a variety of beautiful and performant animated components, including:
+
+- **Animated UI Elements**: Accordion, Dialog, Text Effects, Carousels
+- **Interactive Animations**: Magnetic elements, Spotlights, Tilt effects
+- **Text Animations**: Text morphing, Text loops, Text scramble effects, Spinning text
+- **And many more!**
+
+For the complete list, run `npx motion-primitives list`.
+
+## Dependencies
+
+Most components require the `motion` library. When you add a component, the CLI will automatically install the required dependencies using your preferred package manager.
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.
+
+## License
+
+[MIT](LICENSE)

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,30 +1,30 @@
-# Motion Primitives CLI
+# UI Derrick CLI
 
-A command-line interface for easily adding beautiful, animated components to your React project.
+A command-line interface for easily adding beautiful, reusable components from the ui-derrick registry to your React project.
 
 ## Installation
 
 You can use the CLI directly with npx:
 
 ```bash
-npx motion-primitives <command>
+npx @derricknuby/ui@latest <command>
 ```
 
 Or install it globally:
 
 ```bash
-npm install -g motion-primitives
-motion-primitives <command>
+npm install -g @derricknuby/ui
+ui-derrick <command>
 ```
 
 ## Usage
 
 ### List available components
 
-To see all available animated components:
+To see all available components:
 
 ```bash
-npx motion-primitives list
+npx @derricknuby/ui@latest list
 ```
 
 This will display a list of all available components along with descriptions and required dependencies.
@@ -34,41 +34,94 @@ This will display a list of all available components along with descriptions and
 To add a specific component to your project:
 
 ```bash
-npx motion-primitives add <component-name>
+npx @derricknuby/ui@latest add <component-name>
 ```
 
 For example:
 
 ```bash
-npx motion-primitives add text-morph
+npx @derricknuby/ui@latest add organisation-unit-tree
 ```
 
 This will:
 
-1. Create a `components/motion-primitives` directory in your project (if it doesn't exist)
-2. Download and add the component files
-3. Automatically install any required dependencies using your preferred package manager (npm, yarn, or pnpm)
+1. Check if shadcn/ui is initialized in your project
+2. Create the appropriate `components/ui` directory (if it doesn't exist)
+3. Download and add the component files
+4. Automatically install any required dependencies using your preferred package manager (npm, yarn, or pnpm)
+5. Install any required shadcn/ui components
 
 The CLI automatically detects which package manager you're using based on lock files in your project.
 
+## Prerequisites
+
+Before using the CLI, make sure you have shadcn/ui initialized in your project:
+
+```bash
+npx shadcn@latest init
+```
+
 ## Available Components
 
-Motion Primitives offers a variety of beautiful and performant animated components, including:
+UI Derrick offers a variety of beautiful and reusable components, including:
 
-- **Animated UI Elements**: Accordion, Dialog, Text Effects, Carousels
-- **Interactive Animations**: Magnetic elements, Spotlights, Tilt effects
-- **Text Animations**: Text morphing, Text loops, Text scramble effects, Spinning text
-- **And many more!**
+- **OrganisationUnitTree**: A powerful tree component for displaying hierarchical organization structures with search, selection, lazy loading, and filtering capabilities
+- **And more components coming soon!**
 
-For the complete list, run `npx motion-primitives list`.
+### Component Features
+
+**OrganisationUnitTree:**
+
+- Single/multi selection modes
+- Lazy loading support
+- Search and filtering
+- Level restrictions
+- Keyboard navigation
+- Selection statistics
+- Responsive design
+
+For the complete list, run `npx @derricknuby/ui@latest list`.
 
 ## Dependencies
 
-Most components require the `motion` library. When you add a component, the CLI will automatically install the required dependencies using your preferred package manager.
+Components are built on top of shadcn/ui and may require additional packages like `lucide-react`. When you add a component, the CLI will automatically install the required dependencies and shadcn/ui components.
+
+## Example Usage
+
+After adding a component, you can use it in your project:
+
+```tsx
+import { OrganizationTree } from "@/components/ui/organisation-unit-tree";
+
+const data = [
+  {
+    id: "1",
+    name: "Root Organization",
+    children: [{ id: "2", name: "Department A", parentId: "1" }],
+  },
+];
+
+export default function App() {
+  return (
+    <OrganizationTree
+      data={data}
+      onSelectionChange={(nodes, ids) => console.log("Selected:", ids)}
+      showControls={true}
+      showStats={true}
+    />
+  );
+}
+```
+
+## Documentation
+
+- Website: [https://ui.derrick.rw](https://ui.derrick.rw)
+- Registry: [https://github.com/derrick-nuby/ui-derrick](https://github.com/derrick-nuby/ui-derrick)
+- Shadcn/UI: [https://ui.shadcn.com](https://ui.shadcn.com)
 
 ## Contributing
 
-Contributions are welcome! Please feel free to submit a Pull Request.
+Contributions are welcome! Please feel free to submit a Pull Request to the [ui-derrick repository](https://github.com/derrick-nuby/ui-derrick).
 
 ## License
 

--- a/cli/dist/index.js
+++ b/cli/dist/index.js
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+"use strict";
+/* eslint-disable @typescript-eslint/no-explicit-any */
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const commander_1 = require("commander");
+const fs_1 = require("fs");
+const path_1 = require("path");
+const ora_1 = __importDefault(require("ora"));
+const node_fetch_1 = __importDefault(require("node-fetch"));
+const child_process_1 = require("child_process");
+// Read package.json for version info
+const packageJson = JSON.parse((0, fs_1.readFileSync)((0, path_1.join)(__dirname, '..', 'package.json'), 'utf8'));
+const UI_DERRICK_REGISTRY_URL = 'https://raw.githubusercontent.com/derrick-nuby/ui-derrick/develop/registry.json';
+const UI_DERRICK_BASE_URL = 'https://raw.githubusercontent.com/derrick-nuby/ui-derrick/develop/';
+const TARGET_DIR = 'components/ui';
+async function fetchRegistry(url) {
+    const response = await (0, node_fetch_1.default)(url);
+    if (!response.ok) {
+        throw new Error(`Failed to fetch registry from ${url}: ${response.status}`);
+    }
+    return response.json();
+}
+async function fetchFile(url) {
+    const response = await (0, node_fetch_1.default)(url);
+    if (!response.ok) {
+        throw new Error(`Failed to fetch file from ${url}: ${response.status}`);
+    }
+    return response.text();
+}
+// Detect package manager (npm, yarn, pnpm)
+function detectPackageManager() {
+    try {
+        // Check for yarn.lock or package-lock.json
+        if ((0, fs_1.existsSync)('yarn.lock')) {
+            return 'yarn';
+        }
+        else if ((0, fs_1.existsSync)('pnpm-lock.yaml')) {
+            return 'pnpm';
+        }
+        else {
+            return 'npm'; // Default to npm
+        }
+    }
+    catch (error) {
+        return 'npm'; // Default to npm on error
+    }
+}
+// Install dependencies using detected package manager
+function installDependencies(dependencies) {
+    const packageManager = detectPackageManager();
+    const spinner = (0, ora_1.default)('Installing dependencies...').start();
+    try {
+        const installCommand = packageManager === 'yarn'
+            ? `yarn add ${dependencies.join(' ')}`
+            : packageManager === 'pnpm'
+                ? `pnpm add ${dependencies.join(' ')}`
+                : `npm install ${dependencies.join(' ')}`;
+        (0, child_process_1.execSync)(installCommand, { stdio: 'ignore' });
+        spinner.succeed(`Dependencies installed successfully with ${packageManager}`);
+        return true;
+    }
+    catch (error) {
+        spinner.fail(`Failed to install dependencies: ${error}`);
+        console.log('\nPlease install them manually:');
+        console.log(`${packageManager === 'yarn' ? 'yarn add' : packageManager === 'pnpm' ? 'pnpm add' : 'npm install'} ${dependencies.join(' ')}`);
+        return false;
+    }
+}
+// Display the welcome banner
+function displayBanner() {
+    console.log(`
+┌────────────────────────────────────────────┐
+│                                            │
+│           Derrick UI CLI            │
+│                                            │
+│      Beautiful, animated components        │
+│          for your React projects           │
+│                                            │
+│              Version: ${packageJson.version}               │
+│                                            │
+└────────────────────────────────────────────┘
+  `);
+}
+commander_1.program
+    .name('ui-derrick')
+    .description('CLI to add beautiful, reusable components from ui-derrick registry to your app')
+    .version(packageJson.version);
+commander_1.program
+    .command('add')
+    .argument('<component>', 'The component to add (e.g., accordion, text-morph)')
+    .description('Add a ui-derrick component to your project')
+    .action(async (component) => {
+    const spinner = (0, ora_1.default)(`Adding ${component}...`).start();
+    try {
+        // Fetch the ui-derrick registry
+        const uiDerrickRegistry = await fetchRegistry(UI_DERRICK_REGISTRY_URL);
+        const componentEntry = uiDerrickRegistry.items.find((item) => item.name === component);
+        if (!componentEntry) {
+            spinner.fail(`Component "${component}" not found in ui-derrick registry`);
+            console.log('\nRun "npx @derricknuby/ui list" to see all available components');
+            process.exit(1);
+        }
+        // Collect all files and dependencies
+        const allFiles = [];
+        const allDependencies = new Set(componentEntry.dependencies || []);
+        // Process all files from registry.json
+        for (const file of componentEntry.files) {
+            const content = file.content ||
+                (await fetchFile(`${UI_DERRICK_BASE_URL}${file.path}`));
+            const fileName = file.path.split('/').pop();
+            allFiles.push({ path: fileName, content });
+        }
+        // Create target directory if it doesn't exist
+        if (!(0, fs_1.existsSync)(TARGET_DIR)) {
+            (0, fs_1.mkdirSync)(TARGET_DIR, { recursive: true });
+        }
+        // Write all files to components/ui-derrick/
+        for (const { path, content } of allFiles) {
+            const filePath = (0, path_1.join)(TARGET_DIR, path);
+            (0, fs_1.writeFileSync)(filePath, content);
+            console.log(`✓ Added ${path} to ${filePath}`);
+        }
+        spinner.succeed(`Component "${component}" added successfully!`);
+        // Install dependencies automatically
+        const depsArray = Array.from(allDependencies);
+        if (depsArray.length > 0) {
+            const installSuccess = installDependencies(depsArray);
+            // Add usage example
+            if (componentEntry.title) {
+                const pascalCaseName = component
+                    .split('-')
+                    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+                    .join('');
+                console.log('\nExample usage:');
+                console.log('```jsx');
+                console.log(`import { ${pascalCaseName} } from '@/components/ui-derrick/${component}';`);
+                console.log('\n// Then in your JSX:');
+                console.log(`<${pascalCaseName} />`);
+                console.log('```');
+            }
+        }
+        else {
+            console.log('No additional dependencies needed.');
+        }
+    }
+    catch (error) {
+        spinner.fail(`Error: ${error.message || error}`);
+        process.exit(1);
+    }
+});
+commander_1.program
+    .command('list')
+    .description('List all available ui-derrick components')
+    .action(async () => {
+    const spinner = (0, ora_1.default)('Fetching components...').start();
+    try {
+        // Fetch the ui-derrick registry
+        const uiDerrickRegistry = await fetchRegistry(UI_DERRICK_REGISTRY_URL);
+        spinner.succeed(`Found ${uiDerrickRegistry.items.length} components`);
+        console.log('\nAvailable components:');
+        console.log('====================\n');
+        uiDerrickRegistry.items.forEach((item) => {
+            console.log(`${item.name} - ${item.title}`);
+            if (item.description) {
+                console.log(`  ${item.description}`);
+            }
+            if (item.dependencies && item.dependencies.length > 0) {
+                console.log(`  Dependencies: ${item.dependencies.join(', ')}`);
+            }
+            console.log('');
+        });
+        console.log('\nTo add a component run:');
+        console.log('  npx @derricknuby/ui add <component-name>');
+    }
+    catch (error) {
+        spinner.fail(`Error: ${error.message || error}`);
+        process.exit(1);
+    }
+});
+// Add a default command if no command is provided
+commander_1.program.action(() => {
+    displayBanner();
+    console.log('A tool for adding beautiful, animated components to your React app\n');
+    console.log('Available commands:');
+    console.log('  add <component>  - Add a component to your project');
+    console.log('    Example: npx @derricknuby/ui add text-morph');
+    console.log('\n  list             - List all available components');
+    console.log('    Example: npx @derricknuby/ui list');
+    console.log('\n  --help           - Show help information');
+    console.log('\nDocumentation: https://github.com/derrick-nuby/ui-derrick');
+});
+commander_1.program.parse(process.argv);

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,0 +1,759 @@
+{
+  "name": "motion-primitives",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "motion-primitives",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^9.4.1",
+        "node-fetch": "^2.6.7",
+        "ora": "^5.4.1"
+      },
+      "bin": {
+        "motion-primitives": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^18.0.0",
+        "@types/node-fetch": "^2.6.2",
+        "typescript": "^4.9.5"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "18.19.123",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.123.tgz",
+      "integrity": "sha512-K7DIaHnh0mzVxreCR9qwgNxp3MH9dltPNIEddW9MYUlcKAzm+3grKNSTe2vCJHI1FaLpvpL5JGJrz1UZDKYvDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    }
+  }
+}

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "motion-primitives",
+  "name": "@derricknuby/ui",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "motion-primitives",
+      "name": "@derricknuby/ui",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -14,7 +14,7 @@
         "ora": "^5.4.1"
       },
       "bin": {
-        "motion-primitives": "dist/index.js"
+        "ui-derrick": "dist/index.js"
       },
       "devDependencies": {
         "@types/node": "^18.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "motion-primitives",
+  "version": "0.1.0",
+  "description": "CLI to add beautiful, animated components to your app",
+  "bin": {
+    "motion-primitives": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "tsc -w",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "commander": "^9.4.1",
+    "ora": "^5.4.1",
+    "node-fetch": "^2.6.7"
+  },
+  "devDependencies": {
+    "typescript": "^4.9.5",
+    "@types/node": "^18.0.0",
+    "@types/node-fetch": "^2.6.2"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ibelick/motion-primitives.git",
+    "directory": "cli"
+  },
+  "keywords": [
+    "animation",
+    "components",
+    "motion",
+    "ui",
+    "react",
+    "cli"
+  ],
+  "author": "ibelick",
+  "license": "MIT"
+}

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "motion-primitives",
+  "name": "@derricknuby/ui",
   "version": "0.1.0",
-  "description": "CLI to add beautiful, animated components to your app",
+  "description": "CLI to add beautiful, reusable components from ui-derrick registry to your app",
   "bin": {
-    "motion-primitives": "./dist/index.js"
+    "ui-derrick": "./dist/index.js"
   },
   "scripts": {
     "build": "tsc",
@@ -23,17 +23,23 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/ibelick/motion-primitives.git",
+    "url": "https://github.com/derrick-nuby/ui-derrick.git",
     "directory": "cli"
   },
   "keywords": [
-    "animation",
+    "shadcn",
     "components",
-    "motion",
     "ui",
     "react",
+    "nextjs",
+    "registry",
+    "organisation-tree",
     "cli"
   ],
-  "author": "ibelick",
-  "license": "MIT"
+  "author": "Derrick Nuby",
+  "license": "MIT",
+  "homepage": "https://ui.derrick.rw",
+  "bugs": {
+    "url": "https://github.com/derrick-nuby/ui-derrick/issues"
+  }
 }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -13,11 +13,11 @@ const packageJson = JSON.parse(
   readFileSync(join(__dirname, '..', 'package.json'), 'utf8')
 );
 
-const MOTION_PRIMITIVES_REGISTRY_URL =
-  'https://raw.githubusercontent.com/ibelick/motion-primitives/main/public/c/registry.json';
-const MOTION_PRIMITIVES_BASE_URL =
-  'https://raw.githubusercontent.com/ibelick/motion-primitives/main/';
-const TARGET_DIR = 'components/motion-primitives';
+const UI_DERRICK_REGISTRY_URL =
+  'https://raw.githubusercontent.com/derrick-nuby/ui-derrick/develop/registry.json';
+const UI_DERRICK_BASE_URL =
+  'https://raw.githubusercontent.com/derrick-nuby/ui-derrick/develop/';
+const TARGET_DIR = 'components/ui';
 
 interface FileEntry {
   path: string;
@@ -129,7 +129,7 @@ program
     try {
       // Fetch the motion-primitives registry
       const motionPrimitivesRegistry = await fetchRegistry(
-        MOTION_PRIMITIVES_REGISTRY_URL
+        UI_DERRICK_REGISTRY_URL
       );
       const componentEntry = motionPrimitivesRegistry.items.find(
         (item) => item.name === component
@@ -154,7 +154,7 @@ program
       for (const file of componentEntry.files) {
         const content =
           file.content ||
-          (await fetchFile(`${MOTION_PRIMITIVES_BASE_URL}${file.path}`));
+          (await fetchFile(`${UI_DERRICK_BASE_URL}${file.path}`));
         const fileName = file.path.split('/').pop()!;
         allFiles.push({ path: fileName, content });
       }
@@ -212,7 +212,7 @@ program
     try {
       // Fetch the motion-primitives registry
       const motionPrimitivesRegistry = await fetchRegistry(
-        MOTION_PRIMITIVES_REGISTRY_URL
+        UI_DERRICK_REGISTRY_URL
       );
 
       spinner.succeed(

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { program } from 'commander';
+import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
+import { join } from 'path';
+import ora from 'ora';
+import fetch from 'node-fetch';
+import { execSync } from 'child_process';
+
+// Read package.json for version info
+const packageJson = JSON.parse(
+  readFileSync(join(__dirname, '..', 'package.json'), 'utf8')
+);
+
+const MOTION_PRIMITIVES_REGISTRY_URL =
+  'https://raw.githubusercontent.com/ibelick/motion-primitives/main/public/c/registry.json';
+const MOTION_PRIMITIVES_BASE_URL =
+  'https://raw.githubusercontent.com/ibelick/motion-primitives/main/';
+const TARGET_DIR = 'components/motion-primitives';
+
+interface FileEntry {
+  path: string;
+  type: string;
+  content?: string;
+}
+
+interface RegistryItem {
+  name: string;
+  title?: string;
+  description?: string;
+  dependencies?: string[];
+  registryDependencies?: string[]; // Kept for reference, not used here
+  files: FileEntry[];
+}
+
+interface Registry {
+  items: RegistryItem[];
+}
+
+async function fetchRegistry(url: string): Promise<Registry> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch registry from ${url}: ${response.status}`);
+  }
+  return response.json();
+}
+
+async function fetchFile(url: string): Promise<string> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch file from ${url}: ${response.status}`);
+  }
+  return response.text();
+}
+
+// Detect package manager (npm, yarn, pnpm)
+function detectPackageManager(): string {
+  try {
+    // Check for yarn.lock or package-lock.json
+    if (existsSync('yarn.lock')) {
+      return 'yarn';
+    } else if (existsSync('pnpm-lock.yaml')) {
+      return 'pnpm';
+    } else {
+      return 'npm'; // Default to npm
+    }
+  } catch (error) {
+    return 'npm'; // Default to npm on error
+  }
+}
+
+// Install dependencies using detected package manager
+function installDependencies(dependencies: string[]): boolean {
+  const packageManager = detectPackageManager();
+  const spinner = ora('Installing dependencies...').start();
+
+  try {
+    const installCommand =
+      packageManager === 'yarn'
+        ? `yarn add ${dependencies.join(' ')}`
+        : packageManager === 'pnpm'
+          ? `pnpm add ${dependencies.join(' ')}`
+          : `npm install ${dependencies.join(' ')}`;
+
+    execSync(installCommand, { stdio: 'ignore' });
+    spinner.succeed(
+      `Dependencies installed successfully with ${packageManager}`
+    );
+    return true;
+  } catch (error) {
+    spinner.fail(`Failed to install dependencies: ${error}`);
+    console.log('\nPlease install them manually:');
+    console.log(
+      `${packageManager === 'yarn' ? 'yarn add' : packageManager === 'pnpm' ? 'pnpm add' : 'npm install'} ${dependencies.join(' ')}`
+    );
+    return false;
+  }
+}
+
+// Display the welcome banner
+function displayBanner() {
+  console.log(`
+┌────────────────────────────────────────────┐
+│                                            │
+│           Motion Primitives CLI            │
+│                                            │
+│      Beautiful, animated components        │
+│          for your React projects           │
+│                                            │
+│              Version: ${packageJson.version}               │
+│                                            │
+└────────────────────────────────────────────┘
+  `);
+}
+
+program
+  .name('motion-primitives')
+  .description('CLI to add beautiful, animated components to your app')
+  .version(packageJson.version);
+
+program
+  .command('add')
+  .argument('<component>', 'The component to add (e.g., accordion, text-morph)')
+  .description('Add a motion-primitives component to your project')
+  .action(async (component: string) => {
+    const spinner = ora(`Adding ${component}...`).start();
+
+    try {
+      // Fetch the motion-primitives registry
+      const motionPrimitivesRegistry = await fetchRegistry(
+        MOTION_PRIMITIVES_REGISTRY_URL
+      );
+      const componentEntry = motionPrimitivesRegistry.items.find(
+        (item) => item.name === component
+      );
+      if (!componentEntry) {
+        spinner.fail(
+          `Component "${component}" not found in motion-primitives registry`
+        );
+        console.log(
+          '\nRun "npx motion-primitives list" to see all available components'
+        );
+        process.exit(1);
+      }
+
+      // Collect all files and dependencies
+      const allFiles: { path: string; content: string; }[] = [];
+      const allDependencies: Set<string> = new Set(
+        componentEntry.dependencies || []
+      );
+
+      // Process all files from registry.json
+      for (const file of componentEntry.files) {
+        const content =
+          file.content ||
+          (await fetchFile(`${MOTION_PRIMITIVES_BASE_URL}${file.path}`));
+        const fileName = file.path.split('/').pop()!;
+        allFiles.push({ path: fileName, content });
+      }
+
+      // Create target directory if it doesn't exist
+      if (!existsSync(TARGET_DIR)) {
+        mkdirSync(TARGET_DIR, { recursive: true });
+      }
+
+      // Write all files to components/motion-primitives/
+      for (const { path, content } of allFiles) {
+        const filePath = join(TARGET_DIR, path);
+        writeFileSync(filePath, content);
+        console.log(`✓ Added ${path} to ${filePath}`);
+      }
+
+      spinner.succeed(`Component "${component}" added successfully!`);
+
+      // Install dependencies automatically
+      const depsArray = Array.from(allDependencies);
+      if (depsArray.length > 0) {
+        const installSuccess = installDependencies(depsArray);
+
+        // Add usage example
+        if (componentEntry.title) {
+          const pascalCaseName = component
+            .split('-')
+            .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+            .join('');
+
+          console.log('\nExample usage:');
+          console.log('```jsx');
+          console.log(
+            `import { ${pascalCaseName} } from '@/components/motion-primitives/${component}';`
+          );
+          console.log('\n// Then in your JSX:');
+          console.log(`<${pascalCaseName} />`);
+          console.log('```');
+        }
+      } else {
+        console.log('No additional dependencies needed.');
+      }
+    } catch (error: any) {
+      spinner.fail(`Error: ${error.message || error}`);
+      process.exit(1);
+    }
+  });
+
+program
+  .command('list')
+  .description('List all available motion-primitives components')
+  .action(async () => {
+    const spinner = ora('Fetching components...').start();
+
+    try {
+      // Fetch the motion-primitives registry
+      const motionPrimitivesRegistry = await fetchRegistry(
+        MOTION_PRIMITIVES_REGISTRY_URL
+      );
+
+      spinner.succeed(
+        `Found ${motionPrimitivesRegistry.items.length} components`
+      );
+
+      console.log('\nAvailable components:');
+      console.log('====================\n');
+
+      motionPrimitivesRegistry.items.forEach((item) => {
+        console.log(`${item.name} - ${item.title}`);
+        if (item.description) {
+          console.log(`  ${item.description}`);
+        }
+        if (item.dependencies && item.dependencies.length > 0) {
+          console.log(`  Dependencies: ${item.dependencies.join(', ')}`);
+        }
+        console.log('');
+      });
+
+      console.log('\nTo add a component run:');
+      console.log('  npx motion-primitives add <component-name>');
+    } catch (error: any) {
+      spinner.fail(`Error: ${error.message || error}`);
+      process.exit(1);
+    }
+  });
+
+// Add a default command if no command is provided
+program.action(() => {
+  displayBanner();
+  console.log(
+    'A tool for adding beautiful, animated components to your React app\n'
+  );
+  console.log('Available commands:');
+  console.log('  add <component>  - Add a component to your project');
+  console.log('    Example: npx motion-primitives add text-morph');
+  console.log('\n  list             - List all available components');
+  console.log('    Example: npx motion-primitives list');
+  console.log('\n  --help           - Show help information');
+  console.log('\nDocumentation: https://github.com/ibelick/motion-primitives');
+});
+
+program.parse(process.argv);

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -103,7 +103,7 @@ function displayBanner() {
   console.log(`
 ┌────────────────────────────────────────────┐
 │                                            │
-│           Motion Primitives CLI            │
+│           Derrick UI CLI            │
 │                                            │
 │      Beautiful, animated components        │
 │          for your React projects           │
@@ -115,31 +115,31 @@ function displayBanner() {
 }
 
 program
-  .name('motion-primitives')
-  .description('CLI to add beautiful, animated components to your app')
+  .name('ui-derrick')
+  .description('CLI to add beautiful, reusable components from ui-derrick registry to your app')
   .version(packageJson.version);
 
 program
   .command('add')
   .argument('<component>', 'The component to add (e.g., accordion, text-morph)')
-  .description('Add a motion-primitives component to your project')
+  .description('Add a ui-derrick component to your project')
   .action(async (component: string) => {
     const spinner = ora(`Adding ${component}...`).start();
 
     try {
-      // Fetch the motion-primitives registry
-      const motionPrimitivesRegistry = await fetchRegistry(
+      // Fetch the ui-derrick registry
+      const uiDerrickRegistry = await fetchRegistry(
         UI_DERRICK_REGISTRY_URL
       );
-      const componentEntry = motionPrimitivesRegistry.items.find(
+      const componentEntry = uiDerrickRegistry.items.find(
         (item) => item.name === component
       );
       if (!componentEntry) {
         spinner.fail(
-          `Component "${component}" not found in motion-primitives registry`
+          `Component "${component}" not found in ui-derrick registry`
         );
         console.log(
-          '\nRun "npx motion-primitives list" to see all available components'
+          '\nRun "npx @derricknuby/ui list" to see all available components'
         );
         process.exit(1);
       }
@@ -164,7 +164,7 @@ program
         mkdirSync(TARGET_DIR, { recursive: true });
       }
 
-      // Write all files to components/motion-primitives/
+      // Write all files to components/ui-derrick/
       for (const { path, content } of allFiles) {
         const filePath = join(TARGET_DIR, path);
         writeFileSync(filePath, content);
@@ -188,7 +188,7 @@ program
           console.log('\nExample usage:');
           console.log('```jsx');
           console.log(
-            `import { ${pascalCaseName} } from '@/components/motion-primitives/${component}';`
+            `import { ${pascalCaseName} } from '@/components/ui-derrick/${component}';`
           );
           console.log('\n// Then in your JSX:');
           console.log(`<${pascalCaseName} />`);
@@ -205,24 +205,24 @@ program
 
 program
   .command('list')
-  .description('List all available motion-primitives components')
+  .description('List all available ui-derrick components')
   .action(async () => {
     const spinner = ora('Fetching components...').start();
 
     try {
-      // Fetch the motion-primitives registry
-      const motionPrimitivesRegistry = await fetchRegistry(
+      // Fetch the ui-derrick registry
+      const uiDerrickRegistry = await fetchRegistry(
         UI_DERRICK_REGISTRY_URL
       );
 
       spinner.succeed(
-        `Found ${motionPrimitivesRegistry.items.length} components`
+        `Found ${uiDerrickRegistry.items.length} components`
       );
 
       console.log('\nAvailable components:');
       console.log('====================\n');
 
-      motionPrimitivesRegistry.items.forEach((item) => {
+      uiDerrickRegistry.items.forEach((item) => {
         console.log(`${item.name} - ${item.title}`);
         if (item.description) {
           console.log(`  ${item.description}`);
@@ -234,7 +234,7 @@ program
       });
 
       console.log('\nTo add a component run:');
-      console.log('  npx motion-primitives add <component-name>');
+      console.log('  npx @derricknuby/ui add <component-name>');
     } catch (error: any) {
       spinner.fail(`Error: ${error.message || error}`);
       process.exit(1);
@@ -249,11 +249,11 @@ program.action(() => {
   );
   console.log('Available commands:');
   console.log('  add <component>  - Add a component to your project');
-  console.log('    Example: npx motion-primitives add text-morph');
+  console.log('    Example: npx @derricknuby/ui add text-morph');
   console.log('\n  list             - List all available components');
-  console.log('    Example: npx motion-primitives list');
+  console.log('    Example: npx @derricknuby/ui list');
   console.log('\n  --help           - Show help information');
-  console.log('\nDocumentation: https://github.com/ibelick/motion-primitives');
+  console.log('\nDocumentation: https://github.com/derrick-nuby/ui-derrick');
 });
 
 program.parse(process.argv);

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "CommonJS",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/src/app/own/page.tsx
+++ b/src/app/own/page.tsx
@@ -1,0 +1,608 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { ExternalLink, Copy, Check } from "lucide-react";
+import Image from "next/image";
+import { useState } from "react";
+
+export default function BlogPost() {
+  const [copiedCode, setCopiedCode] = useState<string | null>(null);
+
+  const copyToClipboard = async (text: string, id: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopiedCode(id);
+      setTimeout(() => setCopiedCode(null), 2000);
+    } catch (err) {
+      console.error("Failed to copy text: ", err);
+    }
+  };
+
+  const CodeBlock = ({ children, language, id }: { children: string; language: string; id: string; }) => (
+    <div className="relative group my-6">
+      <div className="flex items-center justify-between bg-gray-800 text-gray-300 px-4 py-2 text-sm rounded-t-lg border border-gray-700">
+        <span className="text-blue-400 font-medium">{language}</span>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => copyToClipboard(children, id)}
+          className="h-6 w-6 p-0 text-gray-400 hover:text-white hover:bg-gray-700"
+        >
+          {copiedCode === id ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+        </Button>
+      </div>
+      <pre className="bg-gray-900 text-gray-100 p-4 rounded-b-lg overflow-x-auto border border-gray-700 border-t-0">
+        <code className="text-sm leading-relaxed">{children}</code>
+      </pre>
+    </div>
+  );
+
+  return (
+    <article className="min-h-screen bg-gray-950 text-gray-100">
+      <div className="w-full h-80 md:h-96 relative overflow-hidden">
+        <Image
+          src="/shadcn-image.jpg"
+          alt="Colorful 3D geometric shapes"
+          className="w-full h-full object-cover"
+          layout="fill"
+        />
+        <div className="absolute inset-0 bg-gradient-to-t from-gray-950/80 to-transparent" />
+      </div>
+
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 -mt-20 relative z-10">
+        {/* Header */}
+        <header className="mb-16 text-center">
+          <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6 leading-tight">
+            How to Create Your Own Shadcn/UI Component Registry
+          </h1>
+          <div className="flex items-center justify-center gap-4 text-gray-400 mb-4">
+            <span>Derrick Nuby — Software Engineer</span>
+          </div>
+          <div className="flex items-center justify-center gap-4 text-gray-500 text-sm mb-8">
+            <span>August 16, 2025</span>
+            <span>•</span>
+            <span>7 minutes</span>
+          </div>
+        </header>
+
+        {/* Introduction */}
+        <div className="mb-12">
+          <p className="text-xl text-gray-300 leading-relaxed mb-8">
+            Shadcn/ui has revolutionized how developers think about UI components. Unlike traditional component libraries that come as black-box npm packages, shadcn/ui provides beautiful, accessible components that you actually own. When you install a shadcn component, the code lands directly in your project - fully customizable, no dependencies to worry about, no version conflicts.
+          </p>
+
+          <p className="text-lg text-gray-300 leading-relaxed mb-8">
+            But here&apos;s what makes shadcn truly powerful: the <strong className="text-white">registry system</strong>. This innovative approach lets you distribute components without the traditional npm packaging friction. Instead of installing packages, you pull components directly into your codebase where you have complete control.
+          </p>
+
+          <p className="text-lg text-gray-300 leading-relaxed mb-8">
+            The benefits are game-changing:
+          </p>
+
+          <div className="grid md:grid-cols-2 gap-6 mb-8">
+            <div className="bg-gray-900/50 p-6 rounded-lg border border-gray-800">
+              <h3 className="text-white font-semibold mb-3 flex items-center gap-2">
+                <span className="text-green-400">🎯</span>
+                Full Ownership
+              </h3>
+              <p className="text-gray-300 text-sm">Components become part of your codebase. Customize, modify, and extend them however you need.</p>
+            </div>
+
+            <div className="bg-gray-900/50 p-6 rounded-lg border border-gray-800">
+              <h3 className="text-white font-semibold mb-3 flex items-center gap-2">
+                <span className="text-blue-400">📦</span>
+                No Dependencies
+              </h3>
+              <p className="text-gray-300 text-sm">No more dependency hell. No version conflicts. Just clean code in your project.</p>
+            </div>
+
+            <div className="bg-gray-900/50 p-6 rounded-lg border border-gray-800">
+              <h3 className="text-white font-semibold mb-3 flex items-center gap-2">
+                <span className="text-purple-400">⚡</span>
+                Easy Distribution
+              </h3>
+              <p className="text-gray-300 text-sm">Share components with a simple URL. No npm publishing, no complex setup.</p>
+            </div>
+
+            <div className="bg-gray-900/50 p-6 rounded-lg border border-gray-800">
+              <h3 className="text-white font-semibold mb-3 flex items-center gap-2">
+                <span className="text-orange-400">🔧</span>
+                Perfect for Teams
+              </h3>
+              <p className="text-gray-300 text-sm">Maintain consistency across projects while allowing customization.</p>
+            </div>
+          </div>
+
+          <p className="text-xl text-gray-300 leading-relaxed">
+            Ready to create your own component registry? In this guide, I&apos;ll show you how to build a registry that others can install with a simple{" "}
+            <code className="bg-gray-800 text-blue-400 px-2 py-1 rounded text-sm font-mono">npx shadcn add</code>{" "}
+            command - just like the official shadcn/ui components.
+          </p>
+        </div>
+
+        {/* What We're Building */}
+        <section className="mb-16">
+          <h2 className="text-3xl md:text-4xl font-bold text-white mb-8">What We&apos;re Building</h2>
+          <div className="mb-8">
+            <p className="text-gray-300 mb-6 text-lg">By the end of this tutorial, you&apos;ll have:</p>
+            <div className="space-y-4 text-gray-300">
+              <div className="flex items-start gap-3">
+                <span className="text-green-400 text-xl">✓</span>
+                <span>Your own component registry hosted online</span>
+              </div>
+              <div className="flex items-start gap-3">
+                <span className="text-green-400 text-xl">✓</span>
+                <span>
+                  A reusable{" "}
+                  <code className="bg-gray-800 text-blue-400 px-2 py-1 rounded text-sm font-mono">
+                    OrganisationUnitTree
+                  </code>{" "}
+                  component
+                </span>
+              </div>
+              <div className="flex items-start gap-3">
+                <span className="text-green-400 text-xl">✓</span>
+                <span>Your own branded CLI tool published to npm</span>
+              </div>
+              <div className="flex items-start gap-3">
+                <span className="text-green-400 text-xl">✓</span>
+                <span>The ability for others to install your components with:</span>
+              </div>
+            </div>
+            <CodeBlock language="bash" id="intro-code-1">
+              {`# Using the official shadcn CLI
+npx shadcn add https://ui.derrick.rw/r/organisation-unit-tree.json`}
+            </CodeBlock>
+            <p className="text-center text-gray-400 my-4">or with your branded CLI:</p>
+            <CodeBlock language="bash" id="intro-code-2">
+              {`# Using your custom CLI
+npx @derricknuby/ui@latest add organisation-unit-tree`}
+            </CodeBlock>
+          </div>
+        </section>
+
+        {/* Prerequisites */}
+        <section className="mb-16">
+          <h2 className="text-3xl md:text-4xl font-bold text-white mb-8">Prerequisites</h2>
+          <div className="space-y-4 text-gray-300">
+            <div className="flex items-start gap-3">
+              <span className="text-blue-400">•</span>
+              <span>Node.js 18+ installed</span>
+            </div>
+            <div className="flex items-start gap-3">
+              <span className="text-blue-400">•</span>
+              <span>Basic knowledge of React and TypeScript</span>
+            </div>
+            <div className="flex items-start gap-3">
+              <span className="text-blue-400">•</span>
+              <span>A GitHub account (for hosting)</span>
+            </div>
+          </div>
+        </section>
+
+        {/* Step 1 */}
+        <section className="mb-16">
+          <h2 className="text-3xl md:text-4xl font-bold text-white mb-8">
+            Step 1: Initialize Your Next.js Project
+          </h2>
+          <p className="text-gray-300 mb-6">
+            First, let&apos;s create a new Next.js project with shadcn/ui:
+          </p>
+          <div className="flex flex-wrap justify-center gap-6 mb-8">
+            <a
+              href="https://nextjs.org/docs/getting-started/installation"
+              className="inline-flex items-center text-blue-400 hover:text-blue-300 font-medium transition-colors"
+            >
+              Next.js Installation <ExternalLink className="ml-1 h-4 w-4" />
+            </a>
+            <a
+              href="https://ui.shadcn.com/docs/installation/next"
+              className="inline-flex items-center text-blue-400 hover:text-blue-300 font-medium transition-colors"
+            >
+              Initialize Shadcn <ExternalLink className="ml-1 h-4 w-4" />
+            </a>
+          </div>
+        </section>
+
+        {/* Step 2 */}
+        <section className="mb-16">
+          <h2 className="text-3xl md:text-4xl font-bold text-white mb-8">
+            Step 2: Install Required Components
+          </h2>
+          <p className="text-gray-300 mb-6">Install the base components we&apos;ll need:</p>
+          <CodeBlock language="bash" id="step2">
+            {`npx @derricknuby/ui@latest add input button badge card`}
+          </CodeBlock>
+        </section>
+
+        {/* Step 3 */}
+        <section className="mb-16">
+          <h2 className="text-3xl md:text-4xl font-bold text-white mb-8">
+            Step 3: Create the Registry Structure
+          </h2>
+          <p className="text-gray-300 mb-6">Create the required folder structure:</p>
+          <CodeBlock language="bash" id="step3-1">
+            {`# Create registry directories
+mkdir -p registry/default/ui`}
+          </CodeBlock>
+          <p className="text-gray-300 my-6">
+            Your project structure should now look like:
+          </p>
+          <CodeBlock language="bash" id="step3-2">
+            {`my-component-registry/
+├── registry/
+│   └── default/
+│       └── ui/
+├── public/
+│   └── r/ (this is auto generated)
+├── src/
+│   └── components/
+│       └── ui/
+└── registry.json (we'll create this)`}
+          </CodeBlock>
+        </section>
+
+        {/* Step 4 */}
+        <section className="mb-16">
+          <h2 className="text-3xl md:text-4xl font-bold text-white mb-8">Step 4: Create Your Component</h2>
+          <p className="text-gray-300 mb-6">
+            Create the{" "}
+            <code className="bg-gray-800 text-blue-400 px-2 py-1 rounded text-sm font-mono">OrganisationUnitTree</code>{" "}
+            component:
+          </p>
+          <CodeBlock language="bash" id="step4-1">
+            {`# Create the component file
+touch registry/default/ui/organisation-unit-tree.tsx`}
+          </CodeBlock>
+          <p className="text-gray-300 my-6">
+            Add the following code to{" "}
+            <code className="bg-gray-800 text-blue-400 px-2 py-1 rounded text-sm font-mono">
+              registry/default/ui/organisation-unit-tree.tsx
+            </code>
+            :
+          </p>
+          <CodeBlock language="typescript" id="step4-2">
+            {`"use client"
+
+import type React from "react"
+
+import { useCallback, useEffect, useState, useMemo } from "react"
+import { Input } from "@/components/ui/input"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Loader2, Search, Users, ChevronDown, ChevronRight, X } from 'lucide-react'
+import { cn } from "@/lib/utils"
+
+// ... continue the component`}
+          </CodeBlock>
+        </section>
+
+        {/* Step 5 */}
+        <section className="mb-16">
+          <h2 className="text-3xl md:text-4xl font-bold text-white mb-8">
+            Step 5: Create Registry Configuration
+          </h2>
+          <p className="text-gray-300 mb-6">
+            Create <code className="bg-gray-800 text-blue-400 px-2 py-1 rounded text-sm font-mono">registry.json</code>{" "}
+            in your project root:
+          </p>
+          <CodeBlock language="json" id="step5">
+            {`{
+  "$schema": "https://ui.shadcn.com/schema/registry.json",
+  "name": "my-component-registry",
+  "homepage": "https://ui.derrick.rw",
+  "items": [
+    {
+      "name": "organisation-unit-tree",
+      "type": "registry:ui",
+      "title": "Organisation Unit Tree",
+      "description": "A tree component for selecting organisation units with lazy loading support",
+      "files": [
+        {
+          "path": "registry/default/ui/organisation-unit-tree.tsx",
+          "type": "registry:ui"
+        }
+      ],
+      "dependencies": ["lucide-react"],
+      "registryDependencies": ["input", "button", "badge", "card"]
+    }
+  ]
+}`}
+          </CodeBlock>
+        </section>
+
+        {/* Step 6 */}
+        <section className="mb-16">
+          <h2 className="text-3xl md:text-4xl font-bold text-white mb-8">Step 6: Build the Registry</h2>
+          <p className="text-gray-300 mb-6">
+            Run the shadcn build command to generate the registry files:
+          </p>
+          <CodeBlock language="bash" id="step6">
+            {`npx shadcn build`}
+          </CodeBlock>
+          <p className="text-gray-300 mt-6">
+            This creates JSON files in the{" "}
+            <code className="bg-gray-800 text-blue-400 px-2 py-1 rounded text-sm font-mono">public/r/</code> directory
+            that can be consumed by the shadcn CLI.
+          </p>
+        </section>
+
+        {/* Step 7 */}
+        <section className="mb-16">
+          <h2 className="text-3xl md:text-4xl font-bold text-white mb-8">Step 7: Deploy Your Registry</h2>
+          <p className="text-gray-300 mb-6">
+            Deploy your project to Vercel (or your preferred hosting):
+          </p>
+          <CodeBlock language="bash" id="step7">
+            {`https://your-domain.vercel.app/r/organisation-unit-tree.json`}
+          </CodeBlock>
+        </section>
+
+        {/* Step 8 */}
+        <section className="mb-16">
+          <h2 className="text-3xl md:text-4xl font-bold text-white mb-8">
+            Step 8: Create Your Own CLI Tool
+          </h2>
+          <p className="text-gray-300 mb-6">
+            Take your registry to the next level by creating your own CLI tool. This allows users to install your components with a branded command like{" "}
+            <code className="bg-gray-800 text-blue-400 px-2 py-1 rounded text-sm font-mono">npx @derricknuby/ui@latest add component</code>
+          </p>
+
+          <h3 className="text-2xl font-semibold text-white mb-6">Create CLI Structure</h3>
+          <CodeBlock language="bash" id="step8-1">
+            {`# Create CLI directory
+mkdir cli && cd cli
+
+# Initialize package.json
+npm init -y
+
+# Install dependencies
+npm install commander ora node-fetch
+npm install -D typescript @types/node @types/node-fetch`}
+          </CodeBlock>
+
+          <h3 className="text-2xl font-semibold text-white mb-6">Configure package.json</h3>
+          <CodeBlock language="json" id="step8-2">
+            {`{
+  "name": "@derricknuby/ui",
+  "version": "0.1.0",
+  "description": "CLI to add beautiful, reusable components from ui-derrick registry",
+  "bin": {
+    "ui-derrick": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "prepublishOnly": "npm run build"
+  }
+}`}
+          </CodeBlock>
+
+          <h3 className="text-2xl font-semibold text-white mb-6">Create CLI Source Code</h3>
+          <p className="text-gray-300 mb-6">Create <code className="bg-gray-800 text-blue-400 px-2 py-1 rounded text-sm font-mono">src/index.ts</code>:</p>
+          <CodeBlock language="typescript" id="step8-3">
+            {`#!/usr/bin/env node
+import { program } from 'commander';
+import { execSync } from 'child_process';
+import ora from 'ora';
+
+program
+  .name('ui-derrick')
+  .description('CLI to add components from ui-derrick registry')
+  .version('0.1.0');
+
+program
+  .command('add')
+  .argument('<component>', 'Component to add')
+  .action(async (component: string) => {
+    const spinner = ora(\`Adding \${component}...\`).start();
+    
+    try {
+      const url = \`https://ui.derrick.rw/r/\${component}.json\`;
+      execSync(\`npx shadcn@latest add \${url}\`, { stdio: 'inherit' });
+      spinner.succeed(\`Component "\${component}" added successfully!\`);
+    } catch (error) {
+      spinner.fail(\`Failed to add component: \${error}\`);
+    }
+  });
+
+program.parse(process.argv);`}
+          </CodeBlock>
+
+          <h3 className="text-2xl font-semibold text-white mb-6">Build and Publish</h3>
+          <CodeBlock language="bash" id="step8-4">
+            {`# Build the CLI
+npm run build
+
+# Test locally
+node dist/index.js --help
+
+# Login to npm
+npm login
+
+# Publish to npm
+npm publish --access public`}
+          </CodeBlock>
+
+          <p className="text-gray-300 mt-6">
+            Now users can install your components using your branded CLI:
+          </p>
+          <CodeBlock language="bash" id="step8-5">
+            {`# Install your component with your CLI
+npx @derricknuby/ui@latest add organisation-unit-tree
+
+# List available components
+npx @derricknuby/ui@latest list`}
+          </CodeBlock>
+        </section>
+
+        {/* Step 9 */}
+        <section className="mb-16">
+          <h2 className="text-3xl md:text-4xl font-bold text-white mb-8">
+            Step 9: Test Installation from Your Registry
+          </h2>
+          <p className="text-gray-300 mb-6">Now anyone can install your component using either method:</p>
+
+          <h3 className="text-xl font-semibold text-white mb-4">Option 1: Direct shadcn command</h3>
+          <CodeBlock language="bash" id="step9-1">
+            {`npx shadcn@latest add https://ui.derrick.rw/r/organisation-unit-tree.json`}
+          </CodeBlock>
+
+          <h3 className="text-xl font-semibold text-white mb-4">Option 2: Your branded CLI</h3>
+          <CodeBlock language="bash" id="step9-2">
+            {`npx @derricknuby/ui@latest add organisation-unit-tree`}
+          </CodeBlock>
+        </section>
+
+        {/* Advanced Features */}
+        <section className="mb-16">
+          <h2 className="text-3xl md:text-4xl font-bold text-white mb-8">Advanced Features</h2>
+
+          <h3 className="text-2xl font-semibold text-white mb-6">Adding Multiple Components</h3>
+          <p className="text-gray-300 mb-6">
+            To add more components to your registry, simply:
+          </p>
+          <div className="space-y-4 text-gray-300 mb-8">
+            <div className="flex items-start gap-3">
+              <span className="text-blue-400 font-bold">1.</span>
+              <span>
+                Create new component files in{" "}
+                <code className="bg-gray-800 text-blue-400 px-2 py-1 rounded text-sm font-mono">
+                  registry/default/ui/
+                </code>
+              </span>
+            </div>
+            <div className="flex items-start gap-3">
+              <span className="text-blue-400 font-bold">2.</span>
+              <span>
+                Add new items to your{" "}
+                <code className="bg-gray-800 text-blue-400 px-2 py-1 rounded text-sm font-mono">registry.json</code>
+              </span>
+            </div>
+            <div className="flex items-start gap-3">
+              <span className="text-blue-400 font-bold">3.</span>
+              <span>
+                Run{" "}
+                <code className="bg-gray-800 text-blue-400 px-2 py-1 rounded text-sm font-mono">npx shadcn build</code>{" "}
+                again
+              </span>
+            </div>
+          </div>
+
+          <h3 className="text-2xl font-semibold text-white mb-6">v0.dev Integration</h3>
+          <p className="text-gray-300 mb-6">
+            Create a link to open your component in v0.dev:
+          </p>
+          <CodeBlock language="bash" id="advanced">
+            {`https://v0.dev?registry=https://your-domain.vercel.app/r/organisation-unit-tree.json`}
+          </CodeBlock>
+        </section>
+
+        {/* Conclusion */}
+        <section className="mb-16">
+          <h2 className="text-3xl md:text-4xl font-bold text-white mb-8">Conclusion</h2>
+          <div className="mb-8">
+            <p className="text-gray-300 mb-8 text-lg">
+              Congratulations! You&apos;ve built a complete component ecosystem with both a registry and a custom CLI tool. Users can now install your components with a simple command, and you can iterate and improve them over time.
+            </p>
+
+            <h4 className="text-xl font-semibold text-white mb-6">What you&apos;ve accomplished:</h4>
+            <div className="space-y-4 text-gray-300 mb-8">
+              <div className="flex items-start gap-3">
+                <span className="text-green-400 text-xl">✅</span>
+                <span>Created a component registry with professional distribution</span>
+              </div>
+              <div className="flex items-start gap-3">
+                <span className="text-green-400 text-xl">✅</span>
+                <span>Built and published your own CLI tool to npm</span>
+              </div>
+              <div className="flex items-start gap-3">
+                <span className="text-green-400 text-xl">✅</span>
+                <span>Enabled easy component installation with branded commands</span>
+              </div>
+              <div className="flex items-start gap-3">
+                <span className="text-green-400 text-xl">✅</span>
+                <span>Set up automatic dependency management</span>
+              </div>
+              <div className="flex items-start gap-3">
+                <span className="text-green-400 text-xl">✅</span>
+                <span>Created a foundation for community contributions</span>
+              </div>
+            </div>
+
+            <h4 className="text-xl font-semibold text-white mb-6">
+              The complete{" "}
+              <code className="bg-gray-800 text-blue-400 px-2 py-1 rounded text-sm font-mono">
+                OrganisationUnitTree
+              </code>{" "}
+              component we built includes:
+            </h4>
+            <div className="space-y-3 text-gray-300">
+              <div className="flex items-start gap-3">
+                <span className="text-blue-400">•</span>
+                <span>Search functionality with real-time filtering</span>
+              </div>
+              <div className="flex items-start gap-3">
+                <span className="text-blue-400">•</span>
+                <span>Single/multi selection modes</span>
+              </div>
+              <div className="flex items-start gap-3">
+                <span className="text-blue-400">•</span>
+                <span>Lazy loading support for large datasets</span>
+              </div>
+              <div className="flex items-start gap-3">
+                <span className="text-blue-400">•</span>
+                <span>Level restrictions and accessibility features</span>
+              </div>
+              <div className="flex items-start gap-3">
+                <span className="text-blue-400">•</span>
+                <span>Full keyboard navigation support</span>
+              </div>
+              <div className="flex items-start gap-3">
+                <span className="text-blue-400">•</span>
+                <span>Mobile-responsive design</span>
+              </div>
+            </div>
+
+            <div className="mt-8 p-6 bg-blue-900/20 border border-blue-400/30 rounded-lg">
+              <h5 className="text-blue-400 font-semibold mb-3">🚀 Ready to Use</h5>
+              <p className="text-gray-300 mb-4">Your CLI is now live on npm! Try it out:</p>
+              <code className="bg-gray-800 text-blue-400 px-4 py-2 rounded block">
+                npx @derricknuby/ui@latest add organisation-unit-tree
+              </code>
+            </div>
+          </div>
+
+          <p className="text-2xl font-medium text-white text-center mb-8">
+            Start building your component library ecosystem today and empower developers worldwide!
+          </p>
+        </section>
+
+        {/* Resources */}
+        <section className="pb-16">
+          <h2 className="text-3xl md:text-4xl font-bold text-white mb-8">Resources</h2>
+          <div className="flex flex-col items-center gap-4">
+            <a
+              href="https://ui.shadcn.com"
+              className="flex items-center text-blue-400 hover:text-blue-300 font-medium transition-colors"
+            >
+              Shadcn/UI Documentation <ExternalLink className="ml-1 h-4 w-4" />
+            </a>
+            <a
+              href="https://ui.shadcn.com/schema/registry.json"
+              className="flex items-center text-blue-400 hover:text-blue-300 font-medium transition-colors"
+            >
+              Component Registry Schema <ExternalLink className="ml-1 h-4 w-4" />
+            </a>
+            <a
+              href="https://github.com/derrick-nuby/ui-derrick"
+              className="flex items-center text-blue-400 hover:text-blue-300 font-medium transition-colors"
+            >
+              Example Registry Source <ExternalLink className="ml-1 h-4 w-4" />
+            </a>
+          </div>
+        </section>
+      </div>
+    </article>
+  );
+}


### PR DESCRIPTION
This pull request introduces a new CLI tool under the `cli` directory for the ui-derrick project. The CLI enables users to easily add reusable React components from the ui-derrick registry to their projects, with automatic dependency management and component listing capabilities. The implementation includes all necessary configuration, documentation, and source code to support publishing and usage via npm.

The most important changes are:

**New CLI Implementation:**

* Added the main CLI source code in `cli/src/index.ts`, providing commands to list available components and add selected components to a user's project, including automatic dependency installation and usage examples.
* Added a comprehensive `cli/README.md` with installation, usage instructions, prerequisites, available components, and contribution guidelines.

**Project Configuration and Packaging:**

* Introduced `cli/package.json` to define the CLI package metadata, dependencies, entry point, and npm publishing configuration.
* Added `cli/tsconfig.json` to configure TypeScript compilation for the CLI source code.

**Ignore and Environment Files:**

* Added `.gitignore` and `.vercelignore` files to exclude build outputs, environment files, drafts, and dependencies from version control and deployment.